### PR TITLE
ci: support Ruby 3.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
           - "3.1"
           - "3.2"
           - "3.3"
+          - "3.4"
         runs-on:
           - macos-latest
           - ubuntu-latest


### PR DESCRIPTION
Ruby 3.4.1 has released.
- https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-1-released/